### PR TITLE
Global build

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -4,18 +4,22 @@
    -->
   <remote name="github" fetch="../../.."/>
 
-  <default remote="github" revision="master" sync-j="4"  />
+  <default remote="github" revision="master" sync-j="4"/>
 
+  <!-- Istio global build -->
+  <project path="build" name="istio/global-build"/>
+ 
   <!-- Istio go components -->
   <project path="go/src/istio.io/api" name="istio/api"/>
   <project path="go/src/istio.io/istio" name="istio/istio"/>
   <project path="go/src/istio.io/test-infra" name="istio/test-infra"/>
-  
+
   <!-- C++ code under src, to avoid poluting the go source path -->
-  <project path="src/proxy" name="istio/proxy" />
+  <project path="src/proxy" name="istio/proxy"/>
+
   <!-- Direct proxy dependencies.
        Mixerclient may be merged with proxy -->
-  <project path="src/envoy" name="envoyproxy/envoy" />
-  <project path="src/mixerclient" name="istio/mixerclient" />
+  <project path="src/envoy" name="envoyproxy/envoy"/>
+  <project path="src/mixerclient" name="istio/mixerclient"/>
 
 </manifest>


### PR DESCRIPTION
I thought it would make sense to add the global build files along with the manifest such that we can update both at the same time.

The artifacts template is temporary, it will be removed once every module have theirs.